### PR TITLE
Usbdevice status feature

### DIFF
--- a/src/usb/qusbdevice.cpp
+++ b/src/usb/qusbdevice.cpp
@@ -374,6 +374,7 @@ qint32 QUsbDevice::open()
     }
 
     m_connected = true;
+    emit connectionChanged(m_connected);
 
     return 0;
 }
@@ -397,6 +398,7 @@ void QUsbDevice::close()
     }
 
     m_connected = false;
+    emit connectionChanged(m_connected);
 }
 
 /*!

--- a/src/usb/qusbdevice.cpp
+++ b/src/usb/qusbdevice.cpp
@@ -11,7 +11,7 @@ QUsbDevicePrivate::QUsbDevicePrivate()
 {
     int r = libusb_init(&m_ctx);
     if (r < 0) {
-	qCritical("LibUsb Init Error %d", r);
+        qCritical("LibUsb Init Error %d", r);
     }
     m_devHandle = Q_NULLPTR;
 
@@ -176,18 +176,18 @@ QUsbDevice::~QUsbDevice()
 QByteArray QUsbDevice::speedString() const
 {
     switch (m_spd) {
-    case unknownSpeed:
-	return "Unknown speed";
-    case lowSpeed:
-	return "Low speed";
-    case fullSpeed:
-	return "Full speed";
-    case highSpeed:
-	return "High speed";
-    case superSpeed:
-	return "Super speed";
-    case superSpeedPlus:
-	return "Super speed plus";
+        case unknownSpeed:
+            return "Unknown speed";
+        case lowSpeed:
+            return "Low speed";
+        case fullSpeed:
+            return "Full speed";
+        case highSpeed:
+            return "High speed";
+        case superSpeed:
+            return "Super speed";
+        case superSpeedPlus:
+            return "Super speed plus";
     }
 
     return "Error";
@@ -201,34 +201,34 @@ QUsbDevice::DeviceStatus QUsbDevice::status() const
 QByteArray QUsbDevice::statusString() const
 {
     switch (m_status) {
-    case statusOK:
-	return "Success (no error)";
-    case statusIoError:
-	return "Input/output error";
-    case statusInvalidParam:
-	return "Invalid parameter";
-    case statusAccessDenied:
-	return "Access denied (insufficient permissions)";
-    case statusNoSuchDevice:
-	return "No such device (it may have been disconnected)";
-    case statusNotFound:
-	return "Entity not found";
-    case statusBusy:
-	return "Resource busy";
-    case statusTimeout:
-	return "Operation timed out";
-    case statusOverflow:
-	return "Overflow";
-    case statusPipeError:
-	return "Pipe error";
-    case statusInterrupted:
-	return "System call interrupted (perhaps due to signal)";
-    case statusNoMemory:
-	return "Insufficient memory";
-    case statusNotSupported:
-	return "Operation not supported or unimplemented on this platform";
-    case statusUnknownError:
-	break;
+        case statusOK:
+            return "Success (no error)";
+        case statusIoError:
+            return "Input/output error";
+        case statusInvalidParam:
+            return "Invalid parameter";
+        case statusAccessDenied:
+            return "Access denied (insufficient permissions)";
+        case statusNoSuchDevice:
+            return "No such device (it may have been disconnected)";
+        case statusNotFound:
+            return "Entity not found";
+        case statusBusy:
+            return "Resource busy";
+        case statusTimeout:
+            return "Operation timed out";
+        case statusOverflow:
+            return "Overflow";
+        case statusPipeError:
+            return "Pipe error";
+        case statusInterrupted:
+            return "System call interrupted (perhaps due to signal)";
+        case statusNoMemory:
+            return "Insufficient memory";
+        case statusNotSupported:
+            return "Operation not supported or unimplemented on this platform";
+        case statusUnknownError:
+            break;
     }
 
     return "Other error";
@@ -239,9 +239,9 @@ void QUsbDevice::handleUsbError(int error_code)
     DbgPrintFuncName();
     DeviceStatus status = static_cast<QUsbDevice::DeviceStatus>(error_code);
     if (status != m_status) {
-	m_status = status;
-	qWarning("Usb device status changed: %s", statusString().constData());
-	emit statusChanged(m_status);
+        m_status = status;
+        qWarning("Usb device status changed: %s", statusString().constData());
+        emit statusChanged(m_status);
     }
 }
 
@@ -259,22 +259,22 @@ QUsbDevice::IdList QUsbDevice::devices()
     libusb_set_debug(ctx, LIBUSB_LOG_LEVEL_NONE);
     cnt = libusb_get_device_list(ctx, &devs); // get the list of devices
     if (cnt < 0) {
-	qCritical("libusb_get_device_list Error");
-	libusb_free_device_list(devs, 1);
-	return list;
+        qCritical("libusb_get_device_list Error");
+        libusb_free_device_list(devs, 1);
+        return list;
     }
 
     for (int i = 0; i < cnt; i++) {
-	libusb_device *dev = devs[i];
-	libusb_device_descriptor desc;
+        libusb_device *dev = devs[i];
+        libusb_device_descriptor desc;
 
-	if (libusb_get_device_descriptor(dev, &desc) == 0) {
-	    Id filter;
-	    filter.pid = desc.idProduct;
-	    filter.vid = desc.idVendor;
+        if (libusb_get_device_descriptor(dev, &desc) == 0) {
+            Id filter;
+            filter.pid = desc.idProduct;
+            filter.vid = desc.idVendor;
 
-	    list.append(filter);
-	}
+            list.append(filter);
+        }
     }
 
     libusb_free_device_list(devs, 1);
@@ -295,88 +295,88 @@ qint32 QUsbDevice::open()
     libusb_device *dev = Q_NULLPTR;
 
     if (m_connected)
-	return -1;
+        return -1;
 
     cnt = libusb_get_device_list(d->m_ctx, &d->m_devs); // get the list of devices
     if (cnt < 0) {
-	qCritical("libusb_get_device_list error");
-	libusb_free_device_list(d->m_devs, 1);
-	return -1;
+        qCritical("libusb_get_device_list error");
+        libusb_free_device_list(d->m_devs, 1);
+        return -1;
     }
 
     for (int i = 0; i < cnt; i++) {
-	dev = d->m_devs[i];
-	libusb_device_descriptor desc;
+        dev = d->m_devs[i];
+        libusb_device_descriptor desc;
 
-	if (libusb_get_device_descriptor(dev, &desc) == 0) {
-	    if (desc.idProduct == m_id.pid && desc.idVendor == m_id.vid) {
-		if (m_log_level >= logInfo)
-		    qInfo("Found device");
+        if (libusb_get_device_descriptor(dev, &desc) == 0) {
+            if (desc.idProduct == m_id.pid && desc.idVendor == m_id.vid) {
+                if (m_log_level >= logInfo)
+                    qInfo("Found device");
 
-		rc = libusb_open(dev, &d->m_devHandle);
-		if (rc == 0)
-		    break;
-		else if (m_log_level >= logWarning) {
-		    qWarning("Failed to open device: %s", libusb_strerror(static_cast<enum libusb_error>(rc)));
-		}
-	    }
-	}
+                rc = libusb_open(dev, &d->m_devHandle);
+                if (rc == 0)
+                    break;
+                else if (m_log_level >= logWarning) {
+                    qWarning("Failed to open device: %s", libusb_strerror(static_cast<enum libusb_error>(rc)));
+                }
+            }
+        }
     }
     libusb_free_device_list(d->m_devs, 1); // free the list, unref the devices in it
 
     if (rc != 0 || d->m_devHandle == Q_NULLPTR) {
-	return rc;
+        return rc;
     }
 
     if (m_log_level >= logInfo)
-	qInfo("Device Open");
+        qInfo("Device Open");
 
     if (libusb_kernel_driver_active(d->m_devHandle, m_config.interface) == 1) { // find out if kernel driver is attached
-	if (m_log_level >= logDebug)
-	    qDebug("Kernel Driver Active");
-	if (libusb_detach_kernel_driver(d->m_devHandle, m_config.interface) == 0) // detach it
-	    if (m_log_level >= logDebug)
-		qDebug("Kernel Driver Detached!");
+        if (m_log_level >= logDebug)
+            qDebug("Kernel Driver Active");
+        if (libusb_detach_kernel_driver(d->m_devHandle, m_config.interface) == 0) // detach it
+            if (m_log_level >= logDebug)
+                qDebug("Kernel Driver Detached!");
     }
 
     int conf;
     libusb_get_configuration(d->m_devHandle, &conf);
 
     if (conf != m_config.config) {
-	if (m_log_level >= logInfo)
-	    qInfo("Configuration needs to be changed");
-	rc = libusb_set_configuration(d->m_devHandle, m_config.config);
-	if (rc != 0) {
-	    if (m_log_level >= logWarning)
-		qWarning("Cannot Set Configuration");
-	    handleUsbError(rc);
-	    return -3;
-	}
+        if (m_log_level >= logInfo)
+            qInfo("Configuration needs to be changed");
+        rc = libusb_set_configuration(d->m_devHandle, m_config.config);
+        if (rc != 0) {
+            if (m_log_level >= logWarning)
+                qWarning("Cannot Set Configuration");
+            handleUsbError(rc);
+            return -3;
+        }
     }
     rc = libusb_claim_interface(d->m_devHandle, m_config.interface);
     if (rc != 0) {
-	if (m_log_level >= logWarning)
-	    qWarning("Cannot Claim Interface");
-	handleUsbError(rc);
-	return -4;
+        if (m_log_level >= logWarning)
+            qWarning("Cannot Claim Interface");
+        handleUsbError(rc);
+        return -4;
     }
 
     switch (libusb_get_device_speed(dev)) {
-    case LIBUSB_SPEED_LOW:
-	this->m_spd = lowSpeed;
-	break;
-    case LIBUSB_SPEED_FULL:
-	this->m_spd = fullSpeed;
-	break;
-    case LIBUSB_SPEED_HIGH:
-	this->m_spd = highSpeed;
-	break;
-    case LIBUSB_SPEED_SUPER:
-	this->m_spd = superSpeed;
-	break;
-    default:
-	this->m_spd = unknownSpeed;
-	break;
+        case LIBUSB_SPEED_LOW:
+            this->m_spd = lowSpeed;
+            break;
+        case LIBUSB_SPEED_FULL:
+            this->m_spd = fullSpeed;
+            break;
+        case LIBUSB_SPEED_HIGH:
+            this->m_spd = highSpeed;
+            break;
+        case LIBUSB_SPEED_SUPER:
+            this->m_spd = superSpeed;
+            break;
+        default:
+            this->m_spd = unknownSpeed;
+            break;
     }
 
     m_connected = true;
@@ -394,13 +394,13 @@ void QUsbDevice::close()
     Q_D(QUsbDevice);
 
     if (d->m_devHandle && m_connected) {
-	// stop any further write attempts whilst we close down
-	if (m_log_level >= logInfo)
-	    qInfo("Closing USB connection");
+        // stop any further write attempts whilst we close down
+        if (m_log_level >= logInfo)
+            qInfo("Closing USB connection");
 
-	libusb_release_interface(d->m_devHandle, 0); // release the claimed interface
-	libusb_close(d->m_devHandle); // close the device we opened
-	d->m_devHandle = Q_NULLPTR;
+        libusb_release_interface(d->m_devHandle, 0); // release the claimed interface
+        libusb_close(d->m_devHandle); // close the device we opened
+        d->m_devHandle = Q_NULLPTR;
     }
 
     m_connected = false;
@@ -415,9 +415,9 @@ void QUsbDevice::setLogLevel(LogLevel level)
     Q_D(QUsbDevice);
     m_log_level = level;
     if (level >= logDebugAll)
-	libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_DEBUG);
+        libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_DEBUG);
     else
-	libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_NONE);
+        libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_NONE);
 }
 
 /*!
@@ -513,13 +513,13 @@ void QUsbEventsThread::run()
 
     timeval t = { 0, 100000 };
     while (!this->isInterruptionRequested()) {
-	if (libusb_event_handling_ok(m_ctx) == 0) {
-	    libusb_unlock_events(m_ctx);
-	    break;
-	}
-	if (libusb_handle_events_timeout_completed(m_ctx, &t, Q_NULLPTR) != 0) {
-	    break;
-	}
+        if (libusb_event_handling_ok(m_ctx) == 0) {
+            libusb_unlock_events(m_ctx);
+            break;
+        }
+        if (libusb_handle_events_timeout_completed(m_ctx, &t, Q_NULLPTR) != 0) {
+            break;
+        }
     }
 }
 
@@ -531,8 +531,8 @@ void QUsbEventsThread::run()
 bool QUsbDevice::Config::operator==(const QUsbDevice::Config &other) const
 {
     return other.config == config &&
-	   other.interface == interface &&
-	   other.alternate == alternate;
+            other.interface == interface &&
+            other.alternate == alternate;
 }
 
 QUsbDevice::Config &QUsbDevice::Config::operator=(const QUsbDevice::Config &other)
@@ -551,7 +551,7 @@ QUsbDevice::Config &QUsbDevice::Config::operator=(const QUsbDevice::Config &othe
 bool QUsbDevice::Id::operator==(const QUsbDevice::Id &other) const
 {
     return other.pid == pid &&
-	   other.vid == vid;
+            other.vid == vid;
 }
 
 QUsbDevice::Id &QUsbDevice::Id::operator=(const QUsbDevice::Id &other)

--- a/src/usb/qusbdevice.cpp
+++ b/src/usb/qusbdevice.cpp
@@ -241,9 +241,6 @@ void QUsbDevice::handleUsbError(int error_code)
     if (status != m_status) {
 	m_status = status;
 	qWarning("Usb device status changed: %s", statusString().constData());
-	if (m_status != QUsbDevice::statusOK && isConnected()) {
-		close();
-	}
 	emit statusChanged(m_status);
     }
 }

--- a/src/usb/qusbdevice.cpp
+++ b/src/usb/qusbdevice.cpp
@@ -11,7 +11,7 @@ QUsbDevicePrivate::QUsbDevicePrivate()
 {
     int r = libusb_init(&m_ctx);
     if (r < 0) {
-        qCritical("LibUsb Init Error %d", r);
+	qCritical("LibUsb Init Error %d", r);
     }
     m_devHandle = Q_NULLPTR;
 
@@ -29,11 +29,6 @@ QUsbDevicePrivate::~QUsbDevicePrivate()
 
     q->close();
     libusb_exit(m_ctx);
-}
-
-void QUsbDevicePrivate::printUsbError(int error_code) const
-{
-    qWarning("libusb Error: %s", libusb_strerror(static_cast<enum libusb_error>(error_code)));
 }
 
 /*!
@@ -182,17 +177,17 @@ QByteArray QUsbDevice::speedString() const
 {
     switch (m_spd) {
     case unknownSpeed:
-        return "Unknown speed";
+	return "Unknown speed";
     case lowSpeed:
-        return "Low speed";
+	return "Low speed";
     case fullSpeed:
-        return "Full speed";
+	return "Full speed";
     case highSpeed:
-        return "High speed";
+	return "High speed";
     case superSpeed:
-        return "Super speed";
+	return "Super speed";
     case superSpeedPlus:
-        return "Super speed plus";
+	return "Super speed plus";
     }
 
     return "Error";
@@ -239,6 +234,20 @@ QByteArray QUsbDevice::statusString() const
     return "Other error";
 }
 
+void QUsbDevice::handleUsbError(int error_code)
+{
+    DbgPrintFuncName();
+    DeviceStatus status = static_cast<QUsbDevice::DeviceStatus>(error_code);
+    if (status != m_status) {
+	m_status = status;
+	qWarning("Usb device status changed: %s", qPrintable(statusString()));
+	if (m_status != QUsbDevice::statusOK && isConnected()) {
+		close();
+	}
+	emit statusChanged(m_status);
+    }
+}
+
 /*!
     \brief Returns all present \c devices.
  */
@@ -253,22 +262,22 @@ QUsbDevice::IdList QUsbDevice::devices()
     libusb_set_debug(ctx, LIBUSB_LOG_LEVEL_NONE);
     cnt = libusb_get_device_list(ctx, &devs); // get the list of devices
     if (cnt < 0) {
-        qCritical("libusb_get_device_list Error");
-        libusb_free_device_list(devs, 1);
-        return list;
+	qCritical("libusb_get_device_list Error");
+	libusb_free_device_list(devs, 1);
+	return list;
     }
 
     for (int i = 0; i < cnt; i++) {
-        libusb_device *dev = devs[i];
-        libusb_device_descriptor desc;
+	libusb_device *dev = devs[i];
+	libusb_device_descriptor desc;
 
-        if (libusb_get_device_descriptor(dev, &desc) == 0) {
-            Id filter;
-            filter.pid = desc.idProduct;
-            filter.vid = desc.idVendor;
+	if (libusb_get_device_descriptor(dev, &desc) == 0) {
+	    Id filter;
+	    filter.pid = desc.idProduct;
+	    filter.vid = desc.idVendor;
 
-            list.append(filter);
-        }
+	    list.append(filter);
+	}
     }
 
     libusb_free_device_list(devs, 1);
@@ -289,88 +298,88 @@ qint32 QUsbDevice::open()
     libusb_device *dev = Q_NULLPTR;
 
     if (m_connected)
-        return -1;
+	return -1;
 
     cnt = libusb_get_device_list(d->m_ctx, &d->m_devs); // get the list of devices
     if (cnt < 0) {
-        qCritical("libusb_get_device_list error");
-        libusb_free_device_list(d->m_devs, 1);
-        return -1;
+	qCritical("libusb_get_device_list error");
+	libusb_free_device_list(d->m_devs, 1);
+	return -1;
     }
 
     for (int i = 0; i < cnt; i++) {
-        dev = d->m_devs[i];
-        libusb_device_descriptor desc;
+	dev = d->m_devs[i];
+	libusb_device_descriptor desc;
 
-        if (libusb_get_device_descriptor(dev, &desc) == 0) {
-            if (desc.idProduct == m_id.pid && desc.idVendor == m_id.vid) {
-                if (m_log_level >= logInfo)
-                    qInfo("Found device");
+	if (libusb_get_device_descriptor(dev, &desc) == 0) {
+	    if (desc.idProduct == m_id.pid && desc.idVendor == m_id.vid) {
+		if (m_log_level >= logInfo)
+		    qInfo("Found device");
 
-                rc = libusb_open(dev, &d->m_devHandle);
-                if (rc == 0)
-                    break;
-                else if (m_log_level >= logWarning) {
-                    qWarning("Failed to open device: %s", libusb_strerror(static_cast<enum libusb_error>(rc)));
-                }
-            }
-        }
+		rc = libusb_open(dev, &d->m_devHandle);
+		if (rc == 0)
+		    break;
+		else if (m_log_level >= logWarning) {
+		    qWarning("Failed to open device: %s", libusb_strerror(static_cast<enum libusb_error>(rc)));
+		}
+	    }
+	}
     }
     libusb_free_device_list(d->m_devs, 1); // free the list, unref the devices in it
 
     if (rc != 0 || d->m_devHandle == Q_NULLPTR) {
-        return rc;
+	return rc;
     }
 
     if (m_log_level >= logInfo)
-        qInfo("Device Open");
+	qInfo("Device Open");
 
     if (libusb_kernel_driver_active(d->m_devHandle, m_config.interface) == 1) { // find out if kernel driver is attached
-        if (m_log_level >= logDebug)
-            qDebug("Kernel Driver Active");
-        if (libusb_detach_kernel_driver(d->m_devHandle, m_config.interface) == 0) // detach it
-            if (m_log_level >= logDebug)
-                qDebug("Kernel Driver Detached!");
+	if (m_log_level >= logDebug)
+	    qDebug("Kernel Driver Active");
+	if (libusb_detach_kernel_driver(d->m_devHandle, m_config.interface) == 0) // detach it
+	    if (m_log_level >= logDebug)
+		qDebug("Kernel Driver Detached!");
     }
 
     int conf;
     libusb_get_configuration(d->m_devHandle, &conf);
 
     if (conf != m_config.config) {
-        if (m_log_level >= logInfo)
-            qInfo("Configuration needs to be changed");
-        rc = libusb_set_configuration(d->m_devHandle, m_config.config);
-        if (rc != 0) {
-            if (m_log_level >= logWarning)
-                qWarning("Cannot Set Configuration");
-            d->printUsbError(rc);
-            return -3;
-        }
+	if (m_log_level >= logInfo)
+	    qInfo("Configuration needs to be changed");
+	rc = libusb_set_configuration(d->m_devHandle, m_config.config);
+	if (rc != 0) {
+	    if (m_log_level >= logWarning)
+		qWarning("Cannot Set Configuration");
+	    handleUsbError(rc);
+	    return -3;
+	}
     }
     rc = libusb_claim_interface(d->m_devHandle, m_config.interface);
     if (rc != 0) {
-        if (m_log_level >= logWarning)
-            qWarning("Cannot Claim Interface");
-        d->printUsbError(rc);
-        return -4;
+	if (m_log_level >= logWarning)
+	    qWarning("Cannot Claim Interface");
+	handleUsbError(rc);
+	return -4;
     }
 
     switch (libusb_get_device_speed(dev)) {
     case LIBUSB_SPEED_LOW:
-        this->m_spd = lowSpeed;
-        break;
+	this->m_spd = lowSpeed;
+	break;
     case LIBUSB_SPEED_FULL:
-        this->m_spd = fullSpeed;
-        break;
+	this->m_spd = fullSpeed;
+	break;
     case LIBUSB_SPEED_HIGH:
-        this->m_spd = highSpeed;
-        break;
+	this->m_spd = highSpeed;
+	break;
     case LIBUSB_SPEED_SUPER:
-        this->m_spd = superSpeed;
-        break;
+	this->m_spd = superSpeed;
+	break;
     default:
-        this->m_spd = unknownSpeed;
-        break;
+	this->m_spd = unknownSpeed;
+	break;
     }
 
     m_connected = true;
@@ -388,13 +397,13 @@ void QUsbDevice::close()
     Q_D(QUsbDevice);
 
     if (d->m_devHandle && m_connected) {
-        // stop any further write attempts whilst we close down
-        if (m_log_level >= logInfo)
-            qInfo("Closing USB connection");
+	// stop any further write attempts whilst we close down
+	if (m_log_level >= logInfo)
+	    qInfo("Closing USB connection");
 
-        libusb_release_interface(d->m_devHandle, 0); // release the claimed interface
-        libusb_close(d->m_devHandle); // close the device we opened
-        d->m_devHandle = Q_NULLPTR;
+	libusb_release_interface(d->m_devHandle, 0); // release the claimed interface
+	libusb_close(d->m_devHandle); // close the device we opened
+	d->m_devHandle = Q_NULLPTR;
     }
 
     m_connected = false;
@@ -409,9 +418,9 @@ void QUsbDevice::setLogLevel(LogLevel level)
     Q_D(QUsbDevice);
     m_log_level = level;
     if (level >= logDebugAll)
-        libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_DEBUG);
+	libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_DEBUG);
     else
-        libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_NONE);
+	libusb_set_debug(d->m_ctx, LIBUSB_LOG_LEVEL_NONE);
 }
 
 /*!
@@ -507,13 +516,13 @@ void QUsbEventsThread::run()
 
     timeval t = { 0, 100000 };
     while (!this->isInterruptionRequested()) {
-        if (libusb_event_handling_ok(m_ctx) == 0) {
-            libusb_unlock_events(m_ctx);
-            break;
-        }
-        if (libusb_handle_events_timeout_completed(m_ctx, &t, Q_NULLPTR) != 0) {
-            break;
-        }
+	if (libusb_event_handling_ok(m_ctx) == 0) {
+	    libusb_unlock_events(m_ctx);
+	    break;
+	}
+	if (libusb_handle_events_timeout_completed(m_ctx, &t, Q_NULLPTR) != 0) {
+	    break;
+	}
     }
 }
 
@@ -525,8 +534,8 @@ void QUsbEventsThread::run()
 bool QUsbDevice::Config::operator==(const QUsbDevice::Config &other) const
 {
     return other.config == config &&
-           other.interface == interface &&
-           other.alternate == alternate;
+	   other.interface == interface &&
+	   other.alternate == alternate;
 }
 
 QUsbDevice::Config &QUsbDevice::Config::operator=(const QUsbDevice::Config &other)
@@ -545,7 +554,7 @@ QUsbDevice::Config &QUsbDevice::Config::operator=(const QUsbDevice::Config &othe
 bool QUsbDevice::Id::operator==(const QUsbDevice::Id &other) const
 {
     return other.pid == pid &&
-           other.vid == vid;
+	   other.vid == vid;
 }
 
 QUsbDevice::Id &QUsbDevice::Id::operator=(const QUsbDevice::Id &other)

--- a/src/usb/qusbdevice.cpp
+++ b/src/usb/qusbdevice.cpp
@@ -240,7 +240,7 @@ void QUsbDevice::handleUsbError(int error_code)
     DeviceStatus status = static_cast<QUsbDevice::DeviceStatus>(error_code);
     if (status != m_status) {
 	m_status = status;
-	qWarning("Usb device status changed: %s", qPrintable(statusString()));
+	qWarning("Usb device status changed: %s", statusString().constData());
 	if (m_status != QUsbDevice::statusOK && isConnected()) {
 		close();
 	}

--- a/src/usb/qusbdevice.cpp
+++ b/src/usb/qusbdevice.cpp
@@ -176,18 +176,18 @@ QUsbDevice::~QUsbDevice()
 QByteArray QUsbDevice::speedString() const
 {
     switch (m_spd) {
-        case unknownSpeed:
-            return "Unknown speed";
-        case lowSpeed:
-            return "Low speed";
-        case fullSpeed:
-            return "Full speed";
-        case highSpeed:
-            return "High speed";
-        case superSpeed:
-            return "Super speed";
-        case superSpeedPlus:
-            return "Super speed plus";
+    case unknownSpeed:
+        return "Unknown speed";
+    case lowSpeed:
+        return "Low speed";
+    case fullSpeed:
+        return "Full speed";
+    case highSpeed:
+        return "High speed";
+    case superSpeed:
+        return "Super speed";
+    case superSpeedPlus:
+        return "Super speed plus";
     }
 
     return "Error";
@@ -201,34 +201,34 @@ QUsbDevice::DeviceStatus QUsbDevice::status() const
 QByteArray QUsbDevice::statusString() const
 {
     switch (m_status) {
-        case statusOK:
-            return "Success (no error)";
-        case statusIoError:
-            return "Input/output error";
-        case statusInvalidParam:
-            return "Invalid parameter";
-        case statusAccessDenied:
-            return "Access denied (insufficient permissions)";
-        case statusNoSuchDevice:
-            return "No such device (it may have been disconnected)";
-        case statusNotFound:
-            return "Entity not found";
-        case statusBusy:
-            return "Resource busy";
-        case statusTimeout:
-            return "Operation timed out";
-        case statusOverflow:
-            return "Overflow";
-        case statusPipeError:
-            return "Pipe error";
-        case statusInterrupted:
-            return "System call interrupted (perhaps due to signal)";
-        case statusNoMemory:
-            return "Insufficient memory";
-        case statusNotSupported:
-            return "Operation not supported or unimplemented on this platform";
-        case statusUnknownError:
-            break;
+    case statusOK:
+        return "Success (no error)";
+    case statusIoError:
+        return "Input/output error";
+    case statusInvalidParam:
+        return "Invalid parameter";
+    case statusAccessDenied:
+        return "Access denied (insufficient permissions)";
+    case statusNoSuchDevice:
+        return "No such device (it may have been disconnected)";
+    case statusNotFound:
+        return "Entity not found";
+    case statusBusy:
+        return "Resource busy";
+    case statusTimeout:
+        return "Operation timed out";
+    case statusOverflow:
+        return "Overflow";
+    case statusPipeError:
+        return "Pipe error";
+    case statusInterrupted:
+        return "System call interrupted (perhaps due to signal)";
+    case statusNoMemory:
+        return "Insufficient memory";
+    case statusNotSupported:
+        return "Operation not supported or unimplemented on this platform";
+    case statusUnknownError:
+        break;
     }
 
     return "Other error";
@@ -362,21 +362,21 @@ qint32 QUsbDevice::open()
     }
 
     switch (libusb_get_device_speed(dev)) {
-        case LIBUSB_SPEED_LOW:
-            this->m_spd = lowSpeed;
-            break;
-        case LIBUSB_SPEED_FULL:
-            this->m_spd = fullSpeed;
-            break;
-        case LIBUSB_SPEED_HIGH:
-            this->m_spd = highSpeed;
-            break;
-        case LIBUSB_SPEED_SUPER:
-            this->m_spd = superSpeed;
-            break;
-        default:
-            this->m_spd = unknownSpeed;
-            break;
+    case LIBUSB_SPEED_LOW:
+        this->m_spd = lowSpeed;
+        break;
+    case LIBUSB_SPEED_FULL:
+        this->m_spd = fullSpeed;
+        break;
+    case LIBUSB_SPEED_HIGH:
+        this->m_spd = highSpeed;
+        break;
+    case LIBUSB_SPEED_SUPER:
+        this->m_spd = superSpeed;
+        break;
+    default:
+        this->m_spd = unknownSpeed;
+        break;
     }
 
     m_connected = true;

--- a/src/usb/qusbdevice.cpp
+++ b/src/usb/qusbdevice.cpp
@@ -164,6 +164,7 @@ QUsbDevice::QUsbDevice(QObject *parent)
     m_config.config = 0x01;
     m_config.interface = 0x00;
     m_config.alternate = 0x00;
+    m_status = statusOK;
     this->setLogLevel(m_log_level); // Apply log level to libusb
 }
 
@@ -195,6 +196,47 @@ QByteArray QUsbDevice::speedString() const
     }
 
     return "Error";
+}
+
+QUsbDevice::DeviceStatus QUsbDevice::status() const
+{
+    return m_status;
+}
+
+QByteArray QUsbDevice::statusString() const
+{
+    switch (m_status) {
+    case statusOK:
+	return "Success (no error)";
+    case statusIoError:
+	return "Input/output error";
+    case statusInvalidParam:
+	return "Invalid parameter";
+    case statusAccessDenied:
+	return "Access denied (insufficient permissions)";
+    case statusNoSuchDevice:
+	return "No such device (it may have been disconnected)";
+    case statusNotFound:
+	return "Entity not found";
+    case statusBusy:
+	return "Resource busy";
+    case statusTimeout:
+	return "Operation timed out";
+    case statusOverflow:
+	return "Overflow";
+    case statusPipeError:
+	return "Pipe error";
+    case statusInterrupted:
+	return "System call interrupted (perhaps due to signal)";
+    case statusNoMemory:
+	return "Insufficient memory";
+    case statusNotSupported:
+	return "Operation not supported or unimplemented on this platform";
+    case statusUnknownError:
+	break;
+    }
+
+    return "Other error";
 }
 
 /*!

--- a/src/usb/qusbdevice.h
+++ b/src/usb/qusbdevice.h
@@ -82,7 +82,7 @@ public:
         statusInterrupted = -10,
         statusNoMemory = -11,
         statusNotSupported = -12,
-        StatusUnknownError = -99,
+	statusUnknownError = -99,
     };
     Q_ENUM(DeviceStatus)
 

--- a/src/usb/qusbdevice.h
+++ b/src/usb/qusbdevice.h
@@ -94,6 +94,7 @@ public:
     Q_PROPERTY(quint16 timeout READ timeout WRITE setTimeout)
     Q_PROPERTY(DeviceSpeed speed READ speed)
     Q_PROPERTY(DeviceStatus status READ status NOTIFY statusChanged)
+    Q_PROPERTY(bool connected READ isConnected NOTIFY connectionChanged)
 
     explicit QUsbDevice(QObject *parent = Q_NULLPTR);
     ~QUsbDevice();

--- a/src/usb/qusbdevice.h
+++ b/src/usb/qusbdevice.h
@@ -93,6 +93,7 @@ public:
     Q_PROPERTY(quint16 vid READ vid)
     Q_PROPERTY(quint16 timeout READ timeout WRITE setTimeout)
     Q_PROPERTY(DeviceSpeed speed READ speed)
+    Q_PROPERTY(DeviceStatus status READ status NOTIFY statusChanged)
 
     explicit QUsbDevice(QObject *parent = Q_NULLPTR);
     ~QUsbDevice();
@@ -110,7 +111,13 @@ public:
     LogLevel logLevel() const;
     DeviceSpeed speed() const;
     QByteArray speedString() const;
+    DeviceStatus status() const;
+    QByteArray statusString() const;
     static IdList devices();
+
+signals:
+    void statusChanged(DeviceStatus status);
+    void connectionChanged(bool connected);
 
 public slots:
     qint32 open();
@@ -126,6 +133,7 @@ private:
     Id m_id;
     Config m_config;
     DeviceSpeed m_spd;
+    DeviceStatus m_status;
 };
 
 Q_DECLARE_METATYPE(QUsbDevice::Config);

--- a/src/usb/qusbdevice.h
+++ b/src/usb/qusbdevice.h
@@ -26,63 +26,63 @@ public:
     typedef quint8 Endpoint;
 
     enum LogLevel : quint8 {
-	logNone = 0,
-	logError = 1,
-	logWarning = 2,
-	logInfo = 3,
-	logDebug = 4,
-	logDebugAll = 5
+        logNone = 0,
+        logError = 1,
+        logWarning = 2,
+        logInfo = 3,
+        logDebug = 4,
+        logDebugAll = 5
     };
 
     class Q_USB_EXPORT Config
     {
     public:
-	quint8 config;
-	quint8 interface;
-	quint8 alternate;
+        quint8 config;
+        quint8 interface;
+        quint8 alternate;
 
-	bool operator==(const QUsbDevice::Config &other) const;
-	QUsbDevice::Config &operator=(const QUsbDevice::Config &other);
+        bool operator==(const QUsbDevice::Config &other) const;
+        QUsbDevice::Config &operator=(const QUsbDevice::Config &other);
     };
 
     class Q_USB_EXPORT Id
     {
     public:
-	quint16 pid;
-	quint16 vid;
+        quint16 pid;
+        quint16 vid;
 
-	bool operator==(const QUsbDevice::Id &other) const;
-	QUsbDevice::Id &operator=(const QUsbDevice::Id &other);
+        bool operator==(const QUsbDevice::Id &other) const;
+        QUsbDevice::Id &operator=(const QUsbDevice::Id &other);
     };
 
     typedef QList<Id> IdList;
     typedef QList<Config> ConfigList;
 
     enum DeviceSpeed : qint8 {
-	unknownSpeed = -1,
-	lowSpeed = 0,
-	fullSpeed,
-	highSpeed,
-	superSpeed,
-	superSpeedPlus
+        unknownSpeed = -1,
+        lowSpeed = 0,
+        fullSpeed,
+        highSpeed,
+        superSpeed,
+        superSpeedPlus
     };
     Q_ENUM(DeviceSpeed)
 
     enum DeviceStatus : qint8 {
-	statusOK = 0,
-	statusIoError = -1,
-	statusInvalidParam = -2,
-	statusAccessDenied = -3,
-	statusNoSuchDevice = -4,
-	statusNotFound = -5,
-	statusBusy = -6,
-	statusTimeout = -7,
-	statusOverflow = -8,
-	statusPipeError = -9,
-	statusInterrupted = -10,
-	statusNoMemory = -11,
-	statusNotSupported = -12,
-	statusUnknownError = -99,
+        statusOK = 0,
+        statusIoError = -1,
+        statusInvalidParam = -2,
+        statusAccessDenied = -3,
+        statusNoSuchDevice = -4,
+        statusNotFound = -5,
+        statusBusy = -6,
+        statusTimeout = -7,
+        statusOverflow = -8,
+        statusPipeError = -9,
+        statusInterrupted = -10,
+        statusNoMemory = -11,
+        statusNotSupported = -12,
+        statusUnknownError = -99,
     };
     Q_ENUM(DeviceStatus)
 

--- a/src/usb/qusbdevice.h
+++ b/src/usb/qusbdevice.h
@@ -120,7 +120,7 @@ private:
     void handleUsbError(int error_code);
 
 signals:
-    void statusChanged(DeviceStatus status);
+    void statusChanged(QUsbDevice::DeviceStatus status);
     void connectionChanged(bool connected);
 
 public slots:

--- a/src/usb/qusbdevice.h
+++ b/src/usb/qusbdevice.h
@@ -26,62 +26,62 @@ public:
     typedef quint8 Endpoint;
 
     enum LogLevel : quint8 {
-        logNone = 0,
-        logError = 1,
-        logWarning = 2,
-        logInfo = 3,
-        logDebug = 4,
-        logDebugAll = 5
+	logNone = 0,
+	logError = 1,
+	logWarning = 2,
+	logInfo = 3,
+	logDebug = 4,
+	logDebugAll = 5
     };
 
     class Q_USB_EXPORT Config
     {
     public:
-        quint8 config;
-        quint8 interface;
-        quint8 alternate;
+	quint8 config;
+	quint8 interface;
+	quint8 alternate;
 
-        bool operator==(const QUsbDevice::Config &other) const;
-        QUsbDevice::Config &operator=(const QUsbDevice::Config &other);
+	bool operator==(const QUsbDevice::Config &other) const;
+	QUsbDevice::Config &operator=(const QUsbDevice::Config &other);
     };
 
     class Q_USB_EXPORT Id
     {
     public:
-        quint16 pid;
-        quint16 vid;
+	quint16 pid;
+	quint16 vid;
 
-        bool operator==(const QUsbDevice::Id &other) const;
-        QUsbDevice::Id &operator=(const QUsbDevice::Id &other);
+	bool operator==(const QUsbDevice::Id &other) const;
+	QUsbDevice::Id &operator=(const QUsbDevice::Id &other);
     };
 
     typedef QList<Id> IdList;
     typedef QList<Config> ConfigList;
 
     enum DeviceSpeed : qint8 {
-        unknownSpeed = -1,
-        lowSpeed = 0,
-        fullSpeed,
-        highSpeed,
-        superSpeed,
-        superSpeedPlus
+	unknownSpeed = -1,
+	lowSpeed = 0,
+	fullSpeed,
+	highSpeed,
+	superSpeed,
+	superSpeedPlus
     };
     Q_ENUM(DeviceSpeed)
 
     enum DeviceStatus : qint8 {
-        statusOK = 0,
-        statusIoError = -1,
-        statusInvalidParam = -2,
-        statusAccessDenied = -3,
-        statusNoSuchDevice = -4,
-        statusNotFound = -5,
-        statusBusy = -6,
-        statusTimeout = -7,
-        statusOverflow = -8,
-        statusPipeError = -9,
-        statusInterrupted = -10,
-        statusNoMemory = -11,
-        statusNotSupported = -12,
+	statusOK = 0,
+	statusIoError = -1,
+	statusInvalidParam = -2,
+	statusAccessDenied = -3,
+	statusNoSuchDevice = -4,
+	statusNotFound = -5,
+	statusBusy = -6,
+	statusTimeout = -7,
+	statusOverflow = -8,
+	statusPipeError = -9,
+	statusInterrupted = -10,
+	statusNoMemory = -11,
+	statusNotSupported = -12,
 	statusUnknownError = -99,
     };
     Q_ENUM(DeviceStatus)
@@ -115,6 +115,9 @@ public:
     DeviceStatus status() const;
     QByteArray statusString() const;
     static IdList devices();
+
+private:
+    void handleUsbError(int error_code);
 
 signals:
     void statusChanged(DeviceStatus status);

--- a/src/usb/qusbdevice_p.h
+++ b/src/usb/qusbdevice_p.h
@@ -32,8 +32,6 @@ public:
     QUsbDevicePrivate();
     ~QUsbDevicePrivate();
 
-    void printUsbError(int error_code) const;
-
     libusb_device **m_devs;
     libusb_device_handle *m_devHandle;
     libusb_context *m_ctx;

--- a/src/usb/qusbtransfer.cpp
+++ b/src/usb/qusbtransfer.cpp
@@ -27,23 +27,23 @@ static void LIBUSB_CALL cb_out(struct libusb_transfer *transfer)
     handler->setStatus(static_cast<QUsbTransfer::Status>(s));
 
     if (handler->logLevel() >= QUsbDevice::logDebug)
-        qDebug("OUT: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
-               transfer->status,
-               transfer->timeout,
-               transfer->endpoint,
-               transfer->actual_length,
-               transfer->length);
+	qDebug("OUT: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
+	       transfer->status,
+	       transfer->timeout,
+	       transfer->endpoint,
+	       transfer->actual_length,
+	       transfer->length);
 
     if (sent > 0) {
-        handler->m_write_buf = handler->m_write_buf.mid(0, total - sent); // Remove what was sent
+	handler->m_write_buf = handler->m_write_buf.mid(0, total - sent); // Remove what was sent
     }
 
     // Send remaining data
     if (total > sent) {
-        transfer->buffer = reinterpret_cast<uchar *>(handler->m_write_buf.data()); // New data pointer
-        transfer->length = handler->m_write_buf.size(); // New size
-        libusb_submit_transfer(transfer);
-        return;
+	transfer->buffer = reinterpret_cast<uchar *>(handler->m_write_buf.data()); // New data pointer
+	transfer->length = handler->m_write_buf.size(); // New size
+	libusb_submit_transfer(transfer);
+	return;
     }
 
     libusb_free_transfer(transfer);
@@ -52,10 +52,10 @@ static void LIBUSB_CALL cb_out(struct libusb_transfer *transfer)
     handler->m_write_buf_mutex.unlock();
 
     if (s != LIBUSB_TRANSFER_COMPLETED) {
-        handler->error(static_cast<QUsbTransfer::Status>(s));
+	handler->error(static_cast<QUsbTransfer::Status>(s));
     }
     if (sent > 0) {
-        handler->bytesWritten(sent);
+	handler->bytesWritten(sent);
     }
 }
 
@@ -69,22 +69,22 @@ static void LIBUSB_CALL cb_in(struct libusb_transfer *transfer)
     const int received = transfer->actual_length;
 
     if (handler->logLevel() >= QUsbDevice::logDebug)
-        qDebug("IN: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
-               transfer->status,
-               transfer->timeout,
-               transfer->endpoint,
-               transfer->actual_length,
-               transfer->length);
+	qDebug("IN: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
+	       transfer->status,
+	       transfer->timeout,
+	       transfer->endpoint,
+	       transfer->actual_length,
+	       transfer->length);
 
     handler->setStatus(static_cast<QUsbTransfer::Status>(s));
     if (s != LIBUSB_TRANSFER_COMPLETED) {
-        handler->error(static_cast<QUsbTransfer::Status>(s));
+	handler->error(static_cast<QUsbTransfer::Status>(s));
     } else {
-        handler->m_read_buf_mutex.lock();
-        const int previous_size = handler->m_read_buf.size();
-        handler->m_read_buf.resize(previous_size + received);
-        memcpy(handler->m_read_buf.data() + previous_size, transfer->buffer, static_cast<ulong>(received));
-        handler->m_read_buf_mutex.unlock();
+	handler->m_read_buf_mutex.lock();
+	const int previous_size = handler->m_read_buf.size();
+	handler->m_read_buf.resize(previous_size + received);
+	memcpy(handler->m_read_buf.data() + previous_size, transfer->buffer, static_cast<ulong>(received));
+	handler->m_read_buf_mutex.unlock();
     }
 
     libusb_free_transfer(transfer);
@@ -94,11 +94,11 @@ static void LIBUSB_CALL cb_in(struct libusb_transfer *transfer)
     handler->m_read_transfer_mutex.unlock();
 
     if (received)
-        handler->readyRead();
+	handler->readyRead();
 
     // Start transfer over if polling is enabled
     if (handler->m_poll) {
-        handler->readUsb(handler->m_poll_size);
+	handler->readUsb(handler->m_poll_size);
     }
 }
 
@@ -133,26 +133,26 @@ void QUsbTransferPrivate::setStatus(QUsbTransfer::Status status)
     q->m_status = status;
     switch (status) {
     case QUsbTransfer::transferCompleted:
-        q->setErrorString(QString::fromUtf8("transferCompleted"));
-        break;
+	q->setErrorString(QString::fromUtf8("transferCompleted"));
+	break;
     case QUsbTransfer::transferError:
-        q->setErrorString(QString::fromUtf8("transferError"));
-        break;
+	q->setErrorString(QString::fromUtf8("transferError"));
+	break;
     case QUsbTransfer::transferTimeout:
-        q->setErrorString(QString::fromUtf8("transferTimeout"));
-        break;
+	q->setErrorString(QString::fromUtf8("transferTimeout"));
+	break;
     case QUsbTransfer::transferCanceled:
-        q->setErrorString(QString::fromUtf8("transferCanceled"));
-        break;
+	q->setErrorString(QString::fromUtf8("transferCanceled"));
+	break;
     case QUsbTransfer::transferStall:
-        q->setErrorString(QString::fromUtf8("transferStall"));
-        break;
+	q->setErrorString(QString::fromUtf8("transferStall"));
+	break;
     case QUsbTransfer::transferNoDevice:
-        q->setErrorString(QString::fromUtf8("transferOverflow"));
-        break;
+	q->setErrorString(QString::fromUtf8("transferOverflow"));
+	break;
     case QUsbTransfer::transferOverflow:
-        q->setErrorString(QString::fromUtf8("transferOverflow"));
-        break;
+	q->setErrorString(QString::fromUtf8("transferOverflow"));
+	break;
     }
 }
 
@@ -174,52 +174,52 @@ bool QUsbTransferPrivate::prepareTransfer(libusb_transfer **tr, libusb_transfer_
     auto timeout = q->m_dev->timeout();
 
     if (q->m_type == QUsbTransfer::bulkTransfer) {
-        *tr = libusb_alloc_transfer(0);
-        libusb_fill_bulk_transfer(*tr,
-                                  handle,
-                                  ep,
-                                  buf,
-                                  maxSize,
-                                  cb,
-                                  this,
-                                  timeout);
+	*tr = libusb_alloc_transfer(0);
+	libusb_fill_bulk_transfer(*tr,
+				  handle,
+				  ep,
+				  buf,
+				  maxSize,
+				  cb,
+				  this,
+				  timeout);
     } else if (q->m_type == QUsbTransfer::interruptTransfer) {
-        *tr = libusb_alloc_transfer(0);
-        libusb_fill_interrupt_transfer(*tr,
-                                       handle,
-                                       ep,
-                                       buf,
-                                       maxSize,
-                                       cb,
-                                       this,
-                                       timeout);
+	*tr = libusb_alloc_transfer(0);
+	libusb_fill_interrupt_transfer(*tr,
+				       handle,
+				       ep,
+				       buf,
+				       maxSize,
+				       cb,
+				       this,
+				       timeout);
     } else if (q->m_type == QUsbTransfer::controlTransfer) {
-        *tr = libusb_alloc_transfer(0);
-        libusb_fill_control_transfer(*tr,
-                                     handle,
-                                     buf,
-                                     cb,
-                                     this,
-                                     timeout);
+	*tr = libusb_alloc_transfer(0);
+	libusb_fill_control_transfer(*tr,
+				     handle,
+				     buf,
+				     cb,
+				     this,
+				     timeout);
     } else if (q->m_type == QUsbTransfer::isochronousTransfer) { // Todo: Proper handling
-        *tr = libusb_alloc_transfer(1);
-        libusb_fill_iso_transfer(*tr,
-                                 handle,
-                                 ep,
-                                 buf,
-                                 maxSize,
-                                 1,
-                                 cb,
-                                 this,
-                                 timeout);
+	*tr = libusb_alloc_transfer(1);
+	libusb_fill_iso_transfer(*tr,
+				 handle,
+				 ep,
+				 buf,
+				 maxSize,
+				 1,
+				 cb,
+				 this,
+				 timeout);
     } else {
-        return false;
+	return false;
     }
 
     if (tr == Q_NULLPTR) {
-        if (this->logLevel() >= QUsbDevice::logWarning)
-            qWarning("QUsbTransferHandler: Transfer buffer allocation failed");
-        return false;
+	if (this->logLevel() >= QUsbDevice::logWarning)
+	    qWarning("QUsbTransferHandler: Transfer buffer allocation failed");
+	return false;
     }
 
     return true;
@@ -228,11 +228,12 @@ bool QUsbTransferPrivate::prepareTransfer(libusb_transfer **tr, libusb_transfer_
 void QUsbTransferPrivate::stopTransfer()
 {
     DbgPrivPrintFuncName();
-    // TODO: check if struc it not already freed
+    // TODO: check if struct it not already freed
+    // HINT: libusb_cancel_transfer is async, callback function is called, dont close device first on deconstruction...
     if (m_transfer_in != Q_NULLPTR)
-        libusb_cancel_transfer(m_transfer_in);
+	libusb_cancel_transfer(m_transfer_in);
     if (m_transfer_out != Q_NULLPTR)
-        libusb_cancel_transfer(m_transfer_out);
+	libusb_cancel_transfer(m_transfer_out);
 }
 
 int QUsbTransferPrivate::readUsb(qint64 maxSize)
@@ -243,23 +244,27 @@ int QUsbTransferPrivate::readUsb(qint64 maxSize)
 
     // check it isn't closed already
     if (!q->m_dev->d_func()->m_devHandle || !q->m_dev->isConnected())
-        return -1;
+	return -1;
 
     if (maxSize == 0)
-        return 0;
+	return 0;
 
     m_read_transfer_mutex.lock();
     m_read_transfer_buf.resize(static_cast<int>(maxSize));
     if (!prepareTransfer(&m_transfer_in, cb_in, m_read_transfer_buf.data(), maxSize, q->m_in_ep))
-        return -1;
+	return -1;
     rc = libusb_submit_transfer(m_transfer_in);
 
     if (rc != LIBUSB_SUCCESS) {
-        q->m_dev->d_func()->printUsbError(rc);
-        libusb_free_transfer(m_transfer_in);
-        m_transfer_in = Q_NULLPTR;
-        m_read_transfer_mutex.unlock();
-        return rc;
+	setStatus(QUsbTransfer::transferError);
+	error(QUsbTransfer::transferError);
+	// TODO: Check if QUsbTransfer::QUsbDevice must be const...
+	QUsbDevice* dev = const_cast<QUsbDevice*>(q->m_dev);
+	dev->handleUsbError(rc);
+	libusb_free_transfer(m_transfer_in);
+	m_transfer_in = Q_NULLPTR;
+	m_read_transfer_mutex.unlock();
+	return rc;
     }
 
     return rc;
@@ -276,15 +281,19 @@ int QUsbTransferPrivate::writeUsb(const char *data, qint64 maxSize)
     memcpy(m_write_buf.data(), data, static_cast<ulong>(maxSize));
 
     if (!prepareTransfer(&m_transfer_out, cb_out, m_write_buf.data(), maxSize, q->m_out_ep))
-        return -1;
+	return -1;
     rc = libusb_submit_transfer(m_transfer_out);
 
     if (rc != LIBUSB_SUCCESS) {
-        q->m_dev->d_func()->printUsbError(rc);
-        libusb_free_transfer(m_transfer_out);
-        m_transfer_out = Q_NULLPTR;
-        m_write_buf_mutex.unlock();
-        return rc;
+	setStatus(QUsbTransfer::transferError);
+	error(QUsbTransfer::transferError);
+	// TODO: Check if QUsbTransfer::QUsbDevice must be const...
+	QUsbDevice* dev = const_cast<QUsbDevice*>(q->m_dev);
+	dev->handleUsbError(rc);
+	libusb_free_transfer(m_transfer_out);
+	m_transfer_out = Q_NULLPTR;
+	m_write_buf_mutex.unlock();
+	return rc;
     }
 
     return rc;
@@ -297,11 +306,11 @@ void QUsbTransferPrivate::setPolling(bool enable)
     m_poll = enable;
 
     if (enable) {
-        // Start polling loop on IN if requirements are met
-        if (q->openMode() & QIODevice::ReadOnly) {
-            // Read once, loop will continue on its own as long as polling is enabled.
-            this->readUsb(m_poll_size);
-        }
+	// Start polling loop on IN if requirements are met
+	if (q->openMode() & QIODevice::ReadOnly) {
+	    // Read once, loop will continue on its own as long as polling is enabled.
+	    this->readUsb(m_poll_size);
+	}
     }
 }
 
@@ -458,15 +467,15 @@ bool QUsbTransfer::open(QIODevice::OpenMode mode)
     // Set polling size to max packet size
     switch (m_type) {
     case bulkTransfer:
-        if (m_dev->speed() >= QUsbDevice::highSpeed)
-            d->m_poll_size = 512;
-        break;
+	if (m_dev->speed() >= QUsbDevice::highSpeed)
+	    d->m_poll_size = 512;
+	break;
     default:
-        d->m_poll_size = 64;
+	d->m_poll_size = 64;
     }
 
     if ((openMode() & ReadOnly && m_type == interruptTransfer) || d->m_poll) {
-        setPolling(true);
+	setPolling(true);
     }
     return b;
 }
@@ -485,7 +494,7 @@ void QUsbTransfer::close()
 
     // Wait for (canceled) transfers to finish
     while (d_func()->m_transfer_in != Q_NULLPTR || d_func()->m_transfer_out != Q_NULLPTR)
-        QThread::msleep(10);
+	QThread::msleep(10);
 }
 
 /*!
@@ -557,8 +566,8 @@ bool QUsbTransfer::waitForBytesWritten(int msecs)
     timer.start();
 
     do {
-        if (!this->bytesToWrite())
-            return true;
+	if (!this->bytesToWrite())
+	    return true;
     } while (timer.elapsed() < msecs);
     return false;
 }
@@ -576,8 +585,8 @@ bool QUsbTransfer::waitForReadyRead(int msecs)
     timer.start();
 
     do {
-        if (this->bytesAvailable())
-            return true;
+	if (this->bytesAvailable())
+	    return true;
     } while (timer.elapsed() < msecs);
     return false;
 }
@@ -623,21 +632,21 @@ bool QUsbTransfer::poll()
     DbgPrintFuncName();
 
     if (!isOpen()) {
-        if (d->logLevel() >= QUsbDevice::logWarning)
-            qWarning("QUsbTransferHandler: Handle not open. Ignoring.");
-        return false;
+	if (d->logLevel() >= QUsbDevice::logWarning)
+	    qWarning("QUsbTransferHandler: Handle not open. Ignoring.");
+	return false;
     }
 
     if (!(openMode() & ReadOnly)) {
-        if (d->logLevel() >= QUsbDevice::logWarning)
-            qWarning("QUsbTransferHandler: Trying to poll without read mode. Ignoring.");
-        return false;
+	if (d->logLevel() >= QUsbDevice::logWarning)
+	    qWarning("QUsbTransferHandler: Trying to poll without read mode. Ignoring.");
+	return false;
     }
 
     if (polling()) {
-        if (d->logLevel() >= QUsbDevice::logWarning)
-            qWarning("QUsbTransferHandler: Trying to poll with automatic polling enabled. Ignoring.");
-        return false;
+	if (d->logLevel() >= QUsbDevice::logWarning)
+	    qWarning("QUsbTransferHandler: Trying to poll with automatic polling enabled. Ignoring.");
+	return false;
     }
 
     d->readUsb(d->m_poll_size);
@@ -668,16 +677,16 @@ qint64 QUsbTransfer::readData(char *data, qint64 maxSize)
     Q_CHECK_PTR(data);
 
     if (maxSize <= 0)
-        return 0;
+	return 0;
 
     QMutexLocker(&d->m_read_buf_mutex);
     qint64 read_size = d->m_read_buf.size();
     if (read_size == 0)
-        return 0;
+	return 0;
     if (!isOpen())
-        return -1;
+	return -1;
     if (read_size > maxSize)
-        read_size = maxSize;
+	read_size = maxSize;
 
     memcpy(data, d->m_read_buf.data(), static_cast<ulong>(read_size));
     d->m_read_buf = d->m_read_buf.mid(static_cast<int>(read_size));
@@ -697,10 +706,10 @@ qint64 QUsbTransfer::writeData(const char *data, qint64 maxSize)
     Q_CHECK_PTR(data);
 
     if (!d->isValid())
-        return -1;
+	return -1;
 
     if (d->writeUsb(data, maxSize) != 0)
-        return -1;
+	return -1;
 
     return maxSize;
 }

--- a/src/usb/qusbtransfer.cpp
+++ b/src/usb/qusbtransfer.cpp
@@ -132,27 +132,27 @@ void QUsbTransferPrivate::setStatus(QUsbTransfer::Status status)
 
     q->m_status = status;
     switch (status) {
-        case QUsbTransfer::transferCompleted:
-            q->setErrorString(QString::fromUtf8("transferCompleted"));
-            break;
-        case QUsbTransfer::transferError:
-            q->setErrorString(QString::fromUtf8("transferError"));
-            break;
-        case QUsbTransfer::transferTimeout:
-            q->setErrorString(QString::fromUtf8("transferTimeout"));
-            break;
-        case QUsbTransfer::transferCanceled:
-            q->setErrorString(QString::fromUtf8("transferCanceled"));
-            break;
-        case QUsbTransfer::transferStall:
-            q->setErrorString(QString::fromUtf8("transferStall"));
-            break;
-        case QUsbTransfer::transferNoDevice:
-            q->setErrorString(QString::fromUtf8("transferOverflow"));
-            break;
-        case QUsbTransfer::transferOverflow:
-            q->setErrorString(QString::fromUtf8("transferOverflow"));
-            break;
+    case QUsbTransfer::transferCompleted:
+        q->setErrorString(QString::fromUtf8("transferCompleted"));
+        break;
+    case QUsbTransfer::transferError:
+        q->setErrorString(QString::fromUtf8("transferError"));
+        break;
+    case QUsbTransfer::transferTimeout:
+        q->setErrorString(QString::fromUtf8("transferTimeout"));
+        break;
+    case QUsbTransfer::transferCanceled:
+        q->setErrorString(QString::fromUtf8("transferCanceled"));
+        break;
+    case QUsbTransfer::transferStall:
+        q->setErrorString(QString::fromUtf8("transferStall"));
+        break;
+    case QUsbTransfer::transferNoDevice:
+        q->setErrorString(QString::fromUtf8("transferOverflow"));
+        break;
+    case QUsbTransfer::transferOverflow:
+        q->setErrorString(QString::fromUtf8("transferOverflow"));
+        break;
     }
 }
 
@@ -466,12 +466,12 @@ bool QUsbTransfer::open(QIODevice::OpenMode mode)
 
     // Set polling size to max packet size
     switch (m_type) {
-        case bulkTransfer:
-            if (m_dev->speed() >= QUsbDevice::highSpeed)
-                d->m_poll_size = 512;
-            break;
-        default:
-            d->m_poll_size = 64;
+    case bulkTransfer:
+        if (m_dev->speed() >= QUsbDevice::highSpeed)
+            d->m_poll_size = 512;
+        break;
+    default:
+        d->m_poll_size = 64;
     }
 
     if ((openMode() & ReadOnly && m_type == interruptTransfer) || d->m_poll) {

--- a/src/usb/qusbtransfer.cpp
+++ b/src/usb/qusbtransfer.cpp
@@ -27,23 +27,23 @@ static void LIBUSB_CALL cb_out(struct libusb_transfer *transfer)
     handler->setStatus(static_cast<QUsbTransfer::Status>(s));
 
     if (handler->logLevel() >= QUsbDevice::logDebug)
-	qDebug("OUT: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
-	       transfer->status,
-	       transfer->timeout,
-	       transfer->endpoint,
-	       transfer->actual_length,
-	       transfer->length);
+        qDebug("OUT: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
+               transfer->status,
+               transfer->timeout,
+               transfer->endpoint,
+               transfer->actual_length,
+               transfer->length);
 
     if (sent > 0) {
-	handler->m_write_buf = handler->m_write_buf.mid(0, total - sent); // Remove what was sent
+        handler->m_write_buf = handler->m_write_buf.mid(0, total - sent); // Remove what was sent
     }
 
     // Send remaining data
     if (total > sent) {
-	transfer->buffer = reinterpret_cast<uchar *>(handler->m_write_buf.data()); // New data pointer
-	transfer->length = handler->m_write_buf.size(); // New size
-	libusb_submit_transfer(transfer);
-	return;
+        transfer->buffer = reinterpret_cast<uchar *>(handler->m_write_buf.data()); // New data pointer
+        transfer->length = handler->m_write_buf.size(); // New size
+        libusb_submit_transfer(transfer);
+        return;
     }
 
     libusb_free_transfer(transfer);
@@ -52,10 +52,10 @@ static void LIBUSB_CALL cb_out(struct libusb_transfer *transfer)
     handler->m_write_buf_mutex.unlock();
 
     if (s != LIBUSB_TRANSFER_COMPLETED) {
-	handler->error(static_cast<QUsbTransfer::Status>(s));
+        handler->error(static_cast<QUsbTransfer::Status>(s));
     }
     if (sent > 0) {
-	handler->bytesWritten(sent);
+        handler->bytesWritten(sent);
     }
 }
 
@@ -69,22 +69,22 @@ static void LIBUSB_CALL cb_in(struct libusb_transfer *transfer)
     const int received = transfer->actual_length;
 
     if (handler->logLevel() >= QUsbDevice::logDebug)
-	qDebug("IN: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
-	       transfer->status,
-	       transfer->timeout,
-	       transfer->endpoint,
-	       transfer->actual_length,
-	       transfer->length);
+        qDebug("IN: status = %d, timeout = %d, endpoint = %x, actual_length = %d, length = %d",
+               transfer->status,
+               transfer->timeout,
+               transfer->endpoint,
+               transfer->actual_length,
+               transfer->length);
 
     handler->setStatus(static_cast<QUsbTransfer::Status>(s));
     if (s != LIBUSB_TRANSFER_COMPLETED) {
-	handler->error(static_cast<QUsbTransfer::Status>(s));
+        handler->error(static_cast<QUsbTransfer::Status>(s));
     } else {
-	handler->m_read_buf_mutex.lock();
-	const int previous_size = handler->m_read_buf.size();
-	handler->m_read_buf.resize(previous_size + received);
-	memcpy(handler->m_read_buf.data() + previous_size, transfer->buffer, static_cast<ulong>(received));
-	handler->m_read_buf_mutex.unlock();
+        handler->m_read_buf_mutex.lock();
+        const int previous_size = handler->m_read_buf.size();
+        handler->m_read_buf.resize(previous_size + received);
+        memcpy(handler->m_read_buf.data() + previous_size, transfer->buffer, static_cast<ulong>(received));
+        handler->m_read_buf_mutex.unlock();
     }
 
     libusb_free_transfer(transfer);
@@ -94,11 +94,11 @@ static void LIBUSB_CALL cb_in(struct libusb_transfer *transfer)
     handler->m_read_transfer_mutex.unlock();
 
     if (received)
-	handler->readyRead();
+        handler->readyRead();
 
     // Start transfer over if polling is enabled
     if (handler->m_poll) {
-	handler->readUsb(handler->m_poll_size);
+        handler->readUsb(handler->m_poll_size);
     }
 }
 
@@ -132,27 +132,27 @@ void QUsbTransferPrivate::setStatus(QUsbTransfer::Status status)
 
     q->m_status = status;
     switch (status) {
-    case QUsbTransfer::transferCompleted:
-	q->setErrorString(QString::fromUtf8("transferCompleted"));
-	break;
-    case QUsbTransfer::transferError:
-	q->setErrorString(QString::fromUtf8("transferError"));
-	break;
-    case QUsbTransfer::transferTimeout:
-	q->setErrorString(QString::fromUtf8("transferTimeout"));
-	break;
-    case QUsbTransfer::transferCanceled:
-	q->setErrorString(QString::fromUtf8("transferCanceled"));
-	break;
-    case QUsbTransfer::transferStall:
-	q->setErrorString(QString::fromUtf8("transferStall"));
-	break;
-    case QUsbTransfer::transferNoDevice:
-	q->setErrorString(QString::fromUtf8("transferOverflow"));
-	break;
-    case QUsbTransfer::transferOverflow:
-	q->setErrorString(QString::fromUtf8("transferOverflow"));
-	break;
+        case QUsbTransfer::transferCompleted:
+            q->setErrorString(QString::fromUtf8("transferCompleted"));
+            break;
+        case QUsbTransfer::transferError:
+            q->setErrorString(QString::fromUtf8("transferError"));
+            break;
+        case QUsbTransfer::transferTimeout:
+            q->setErrorString(QString::fromUtf8("transferTimeout"));
+            break;
+        case QUsbTransfer::transferCanceled:
+            q->setErrorString(QString::fromUtf8("transferCanceled"));
+            break;
+        case QUsbTransfer::transferStall:
+            q->setErrorString(QString::fromUtf8("transferStall"));
+            break;
+        case QUsbTransfer::transferNoDevice:
+            q->setErrorString(QString::fromUtf8("transferOverflow"));
+            break;
+        case QUsbTransfer::transferOverflow:
+            q->setErrorString(QString::fromUtf8("transferOverflow"));
+            break;
     }
 }
 
@@ -174,52 +174,52 @@ bool QUsbTransferPrivate::prepareTransfer(libusb_transfer **tr, libusb_transfer_
     auto timeout = q->m_dev->timeout();
 
     if (q->m_type == QUsbTransfer::bulkTransfer) {
-	*tr = libusb_alloc_transfer(0);
-	libusb_fill_bulk_transfer(*tr,
-				  handle,
-				  ep,
-				  buf,
-				  maxSize,
-				  cb,
-				  this,
-				  timeout);
+        *tr = libusb_alloc_transfer(0);
+        libusb_fill_bulk_transfer(*tr,
+                                  handle,
+                                  ep,
+                                  buf,
+                                  maxSize,
+                                  cb,
+                                  this,
+                                  timeout);
     } else if (q->m_type == QUsbTransfer::interruptTransfer) {
-	*tr = libusb_alloc_transfer(0);
-	libusb_fill_interrupt_transfer(*tr,
-				       handle,
-				       ep,
-				       buf,
-				       maxSize,
-				       cb,
-				       this,
-				       timeout);
+        *tr = libusb_alloc_transfer(0);
+        libusb_fill_interrupt_transfer(*tr,
+                                       handle,
+                                       ep,
+                                       buf,
+                                       maxSize,
+                                       cb,
+                                       this,
+                                       timeout);
     } else if (q->m_type == QUsbTransfer::controlTransfer) {
-	*tr = libusb_alloc_transfer(0);
-	libusb_fill_control_transfer(*tr,
-				     handle,
-				     buf,
-				     cb,
-				     this,
-				     timeout);
+        *tr = libusb_alloc_transfer(0);
+        libusb_fill_control_transfer(*tr,
+                                     handle,
+                                     buf,
+                                     cb,
+                                     this,
+                                     timeout);
     } else if (q->m_type == QUsbTransfer::isochronousTransfer) { // Todo: Proper handling
-	*tr = libusb_alloc_transfer(1);
-	libusb_fill_iso_transfer(*tr,
-				 handle,
-				 ep,
-				 buf,
-				 maxSize,
-				 1,
-				 cb,
-				 this,
-				 timeout);
+        *tr = libusb_alloc_transfer(1);
+        libusb_fill_iso_transfer(*tr,
+                                 handle,
+                                 ep,
+                                 buf,
+                                 maxSize,
+                                 1,
+                                 cb,
+                                 this,
+                                 timeout);
     } else {
-	return false;
+        return false;
     }
 
     if (tr == Q_NULLPTR) {
-	if (this->logLevel() >= QUsbDevice::logWarning)
-	    qWarning("QUsbTransferHandler: Transfer buffer allocation failed");
-	return false;
+        if (this->logLevel() >= QUsbDevice::logWarning)
+            qWarning("QUsbTransferHandler: Transfer buffer allocation failed");
+        return false;
     }
 
     return true;
@@ -231,9 +231,9 @@ void QUsbTransferPrivate::stopTransfer()
     // TODO: check if struct it not already freed
     // HINT: libusb_cancel_transfer is async, callback function is called, dont close device first on deconstruction...
     if (m_transfer_in != Q_NULLPTR)
-	libusb_cancel_transfer(m_transfer_in);
+        libusb_cancel_transfer(m_transfer_in);
     if (m_transfer_out != Q_NULLPTR)
-	libusb_cancel_transfer(m_transfer_out);
+        libusb_cancel_transfer(m_transfer_out);
 }
 
 int QUsbTransferPrivate::readUsb(qint64 maxSize)
@@ -244,27 +244,27 @@ int QUsbTransferPrivate::readUsb(qint64 maxSize)
 
     // check it isn't closed already
     if (!q->m_dev->d_func()->m_devHandle || !q->m_dev->isConnected())
-	return -1;
+        return -1;
 
     if (maxSize == 0)
-	return 0;
+        return 0;
 
     m_read_transfer_mutex.lock();
     m_read_transfer_buf.resize(static_cast<int>(maxSize));
     if (!prepareTransfer(&m_transfer_in, cb_in, m_read_transfer_buf.data(), maxSize, q->m_in_ep))
-	return -1;
+        return -1;
     rc = libusb_submit_transfer(m_transfer_in);
 
     if (rc != LIBUSB_SUCCESS) {
-	setStatus(QUsbTransfer::transferError);
-	error(QUsbTransfer::transferError);
-	// TODO: Check if QUsbTransfer::QUsbDevice must be const...
-	QUsbDevice* dev = const_cast<QUsbDevice*>(q->m_dev);
-	dev->handleUsbError(rc);
-	libusb_free_transfer(m_transfer_in);
-	m_transfer_in = Q_NULLPTR;
-	m_read_transfer_mutex.unlock();
-	return rc;
+        setStatus(QUsbTransfer::transferError);
+        error(QUsbTransfer::transferError);
+        // TODO: Check if QUsbTransfer::QUsbDevice must be const...
+        QUsbDevice* dev = const_cast<QUsbDevice*>(q->m_dev);
+        dev->handleUsbError(rc);
+        libusb_free_transfer(m_transfer_in);
+        m_transfer_in = Q_NULLPTR;
+        m_read_transfer_mutex.unlock();
+        return rc;
     }
 
     return rc;
@@ -281,19 +281,19 @@ int QUsbTransferPrivate::writeUsb(const char *data, qint64 maxSize)
     memcpy(m_write_buf.data(), data, static_cast<ulong>(maxSize));
 
     if (!prepareTransfer(&m_transfer_out, cb_out, m_write_buf.data(), maxSize, q->m_out_ep))
-	return -1;
+        return -1;
     rc = libusb_submit_transfer(m_transfer_out);
 
     if (rc != LIBUSB_SUCCESS) {
-	setStatus(QUsbTransfer::transferError);
-	error(QUsbTransfer::transferError);
-	// TODO: Check if QUsbTransfer::QUsbDevice must be const...
-	QUsbDevice* dev = const_cast<QUsbDevice*>(q->m_dev);
-	dev->handleUsbError(rc);
-	libusb_free_transfer(m_transfer_out);
-	m_transfer_out = Q_NULLPTR;
-	m_write_buf_mutex.unlock();
-	return rc;
+        setStatus(QUsbTransfer::transferError);
+        error(QUsbTransfer::transferError);
+        // TODO: Check if QUsbTransfer::QUsbDevice must be const...
+        QUsbDevice* dev = const_cast<QUsbDevice*>(q->m_dev);
+        dev->handleUsbError(rc);
+        libusb_free_transfer(m_transfer_out);
+        m_transfer_out = Q_NULLPTR;
+        m_write_buf_mutex.unlock();
+        return rc;
     }
 
     return rc;
@@ -306,11 +306,11 @@ void QUsbTransferPrivate::setPolling(bool enable)
     m_poll = enable;
 
     if (enable) {
-	// Start polling loop on IN if requirements are met
-	if (q->openMode() & QIODevice::ReadOnly) {
-	    // Read once, loop will continue on its own as long as polling is enabled.
-	    this->readUsb(m_poll_size);
-	}
+        // Start polling loop on IN if requirements are met
+        if (q->openMode() & QIODevice::ReadOnly) {
+            // Read once, loop will continue on its own as long as polling is enabled.
+            this->readUsb(m_poll_size);
+        }
     }
 }
 
@@ -466,16 +466,16 @@ bool QUsbTransfer::open(QIODevice::OpenMode mode)
 
     // Set polling size to max packet size
     switch (m_type) {
-    case bulkTransfer:
-	if (m_dev->speed() >= QUsbDevice::highSpeed)
-	    d->m_poll_size = 512;
-	break;
-    default:
-	d->m_poll_size = 64;
+        case bulkTransfer:
+            if (m_dev->speed() >= QUsbDevice::highSpeed)
+                d->m_poll_size = 512;
+            break;
+        default:
+            d->m_poll_size = 64;
     }
 
     if ((openMode() & ReadOnly && m_type == interruptTransfer) || d->m_poll) {
-	setPolling(true);
+        setPolling(true);
     }
     return b;
 }
@@ -494,7 +494,7 @@ void QUsbTransfer::close()
 
     // Wait for (canceled) transfers to finish
     while (d_func()->m_transfer_in != Q_NULLPTR || d_func()->m_transfer_out != Q_NULLPTR)
-	QThread::msleep(10);
+        QThread::msleep(10);
 }
 
 /*!
@@ -566,8 +566,8 @@ bool QUsbTransfer::waitForBytesWritten(int msecs)
     timer.start();
 
     do {
-	if (!this->bytesToWrite())
-	    return true;
+        if (!this->bytesToWrite())
+            return true;
     } while (timer.elapsed() < msecs);
     return false;
 }
@@ -585,8 +585,8 @@ bool QUsbTransfer::waitForReadyRead(int msecs)
     timer.start();
 
     do {
-	if (this->bytesAvailable())
-	    return true;
+        if (this->bytesAvailable())
+            return true;
     } while (timer.elapsed() < msecs);
     return false;
 }
@@ -632,21 +632,21 @@ bool QUsbTransfer::poll()
     DbgPrintFuncName();
 
     if (!isOpen()) {
-	if (d->logLevel() >= QUsbDevice::logWarning)
-	    qWarning("QUsbTransferHandler: Handle not open. Ignoring.");
-	return false;
+        if (d->logLevel() >= QUsbDevice::logWarning)
+            qWarning("QUsbTransferHandler: Handle not open. Ignoring.");
+        return false;
     }
 
     if (!(openMode() & ReadOnly)) {
-	if (d->logLevel() >= QUsbDevice::logWarning)
-	    qWarning("QUsbTransferHandler: Trying to poll without read mode. Ignoring.");
-	return false;
+        if (d->logLevel() >= QUsbDevice::logWarning)
+            qWarning("QUsbTransferHandler: Trying to poll without read mode. Ignoring.");
+        return false;
     }
 
     if (polling()) {
-	if (d->logLevel() >= QUsbDevice::logWarning)
-	    qWarning("QUsbTransferHandler: Trying to poll with automatic polling enabled. Ignoring.");
-	return false;
+        if (d->logLevel() >= QUsbDevice::logWarning)
+            qWarning("QUsbTransferHandler: Trying to poll with automatic polling enabled. Ignoring.");
+        return false;
     }
 
     d->readUsb(d->m_poll_size);
@@ -677,16 +677,16 @@ qint64 QUsbTransfer::readData(char *data, qint64 maxSize)
     Q_CHECK_PTR(data);
 
     if (maxSize <= 0)
-	return 0;
+        return 0;
 
     QMutexLocker(&d->m_read_buf_mutex);
     qint64 read_size = d->m_read_buf.size();
     if (read_size == 0)
-	return 0;
+        return 0;
     if (!isOpen())
-	return -1;
+        return -1;
     if (read_size > maxSize)
-	read_size = maxSize;
+        read_size = maxSize;
 
     memcpy(data, d->m_read_buf.data(), static_cast<ulong>(read_size));
     d->m_read_buf = d->m_read_buf.mid(static_cast<int>(read_size));
@@ -706,10 +706,10 @@ qint64 QUsbTransfer::writeData(const char *data, qint64 maxSize)
     Q_CHECK_PTR(data);
 
     if (!d->isValid())
-	return -1;
+        return -1;
 
     if (d->writeUsb(data, maxSize) != 0)
-	return -1;
+        return -1;
 
     return maxSize;
 }

--- a/src/usb/qusbtransfer.h
+++ b/src/usb/qusbtransfer.h
@@ -14,51 +14,51 @@ class Q_USB_EXPORT QUsbTransfer : public QIODevice
 
 public:
     enum Type : quint8 {
-        controlTransfer = 0,
-        isochronousTransfer,
-        bulkTransfer,
-        interruptTransfer,
-        streamTransfer
+	controlTransfer = 0,
+	isochronousTransfer,
+	bulkTransfer,
+	interruptTransfer,
+	streamTransfer
     };
     Q_ENUM(Type)
 
     enum Status : quint8 {
-        transferCompleted,
-        transferError,
-        transferTimeout,
-        transferCanceled,
-        transferStall,
-        transferNoDevice,
-        transferOverflow,
+	transferCompleted,
+	transferError,
+	transferTimeout,
+	transferCanceled,
+	transferStall,
+	transferNoDevice,
+	transferOverflow,
     };
     Q_ENUM(Status)
 
     enum bmRequestType : quint8 {
-        requestStandard = (0x00 < 5),
-        requestClass = (0x01 < 5),
-        requestVendor = (0x02 < 5),
-        requestReserved = (0x03 < 5),
-        recipientDevice = 0x00,
-        recipientInterface = 0x01,
-        recipientEndpoint = 0x02,
-        recipientOther = 0x03
+	requestStandard = (0x00 < 5),
+	requestClass = (0x01 < 5),
+	requestVendor = (0x02 < 5),
+	requestReserved = (0x03 < 5),
+	recipientDevice = 0x00,
+	recipientInterface = 0x01,
+	recipientEndpoint = 0x02,
+	recipientOther = 0x03
     };
     Q_ENUM(bmRequestType)
 
     enum bRequest : quint8 {
-        requestGetStatus = 0x00,
-        requestClearFeature = 0x01,
-        requestSetFeature = 0x03,
-        requestSetAddress = 0x05,
-        requestGetDescriptor = 0x06,
-        requestSetDescriptor = 0x07,
-        requestGetConfiguration = 0x08,
-        requestSetConfiguration = 0x09,
-        requestGetInterface = 0x0A,
-        requestSetInterface = 0x0B,
-        requestSynchFrame = 0x0C,
-        requestSetSel = 0x30,
-        requestIsochDelay = 0x31
+	requestGetStatus = 0x00,
+	requestClearFeature = 0x01,
+	requestSetFeature = 0x03,
+	requestSetAddress = 0x05,
+	requestGetDescriptor = 0x06,
+	requestSetDescriptor = 0x07,
+	requestGetConfiguration = 0x08,
+	requestSetConfiguration = 0x09,
+	requestGetInterface = 0x0A,
+	requestSetInterface = 0x0B,
+	requestSynchFrame = 0x0C,
+	requestSetSel = 0x30,
+	requestIsochDelay = 0x31
     };
     Q_ENUM(bRequest)
 
@@ -68,9 +68,9 @@ public:
     Q_PROPERTY(bool polling READ polling WRITE setPolling)
 
     explicit QUsbTransfer(QUsbDevice *dev,
-                          Type type,
-                          QUsbDevice::Endpoint in,
-                          QUsbDevice::Endpoint out);
+			  Type type,
+			  QUsbDevice::Endpoint in,
+			  QUsbDevice::Endpoint out);
     ~QUsbTransfer();
 
     bool open(QIODevice::OpenMode mode);
@@ -89,11 +89,11 @@ public:
     bool waitForReadyRead(int msecs);
 
     void makeControlPacket(char *buffer,
-                           QUsbTransfer::bmRequestType bmRequestType,
-                           QUsbTransfer::bRequest bRequest,
-                           quint16 wValue,
-                           quint16 wIndex,
-                           quint16 wLength) const;
+			   QUsbTransfer::bmRequestType bmRequestType,
+			   QUsbTransfer::bRequest bRequest,
+			   quint16 wValue,
+			   quint16 wIndex,
+			   quint16 wLength) const;
 
     void setPolling(bool enable);
     bool polling();
@@ -103,7 +103,7 @@ public slots:
     void cancelTransfer();
 
 Q_SIGNALS:
-    void error(Status error);
+    void error(QUsbTransfer::Status error);
 
 protected:
     qint64 readData(char *data, qint64 maxSize);

--- a/src/usb/qusbtransfer.h
+++ b/src/usb/qusbtransfer.h
@@ -14,51 +14,51 @@ class Q_USB_EXPORT QUsbTransfer : public QIODevice
 
 public:
     enum Type : quint8 {
-	controlTransfer = 0,
-	isochronousTransfer,
-	bulkTransfer,
-	interruptTransfer,
-	streamTransfer
+        controlTransfer = 0,
+        isochronousTransfer,
+        bulkTransfer,
+        interruptTransfer,
+        streamTransfer
     };
     Q_ENUM(Type)
 
     enum Status : quint8 {
-	transferCompleted,
-	transferError,
-	transferTimeout,
-	transferCanceled,
-	transferStall,
-	transferNoDevice,
-	transferOverflow,
+        transferCompleted,
+        transferError,
+        transferTimeout,
+        transferCanceled,
+        transferStall,
+        transferNoDevice,
+        transferOverflow,
     };
     Q_ENUM(Status)
 
     enum bmRequestType : quint8 {
-	requestStandard = (0x00 < 5),
-	requestClass = (0x01 < 5),
-	requestVendor = (0x02 < 5),
-	requestReserved = (0x03 < 5),
-	recipientDevice = 0x00,
-	recipientInterface = 0x01,
-	recipientEndpoint = 0x02,
-	recipientOther = 0x03
+        requestStandard = (0x00 < 5),
+        requestClass = (0x01 < 5),
+        requestVendor = (0x02 < 5),
+        requestReserved = (0x03 < 5),
+        recipientDevice = 0x00,
+        recipientInterface = 0x01,
+        recipientEndpoint = 0x02,
+        recipientOther = 0x03
     };
     Q_ENUM(bmRequestType)
 
     enum bRequest : quint8 {
-	requestGetStatus = 0x00,
-	requestClearFeature = 0x01,
-	requestSetFeature = 0x03,
-	requestSetAddress = 0x05,
-	requestGetDescriptor = 0x06,
-	requestSetDescriptor = 0x07,
-	requestGetConfiguration = 0x08,
-	requestSetConfiguration = 0x09,
-	requestGetInterface = 0x0A,
-	requestSetInterface = 0x0B,
-	requestSynchFrame = 0x0C,
-	requestSetSel = 0x30,
-	requestIsochDelay = 0x31
+        requestGetStatus = 0x00,
+        requestClearFeature = 0x01,
+        requestSetFeature = 0x03,
+        requestSetAddress = 0x05,
+        requestGetDescriptor = 0x06,
+        requestSetDescriptor = 0x07,
+        requestGetConfiguration = 0x08,
+        requestSetConfiguration = 0x09,
+        requestGetInterface = 0x0A,
+        requestSetInterface = 0x0B,
+        requestSynchFrame = 0x0C,
+        requestSetSel = 0x30,
+        requestIsochDelay = 0x31
     };
     Q_ENUM(bRequest)
 
@@ -68,9 +68,9 @@ public:
     Q_PROPERTY(bool polling READ polling WRITE setPolling)
 
     explicit QUsbTransfer(QUsbDevice *dev,
-			  Type type,
-			  QUsbDevice::Endpoint in,
-			  QUsbDevice::Endpoint out);
+                          Type type,
+                          QUsbDevice::Endpoint in,
+                          QUsbDevice::Endpoint out);
     ~QUsbTransfer();
 
     bool open(QIODevice::OpenMode mode);
@@ -89,11 +89,11 @@ public:
     bool waitForReadyRead(int msecs);
 
     void makeControlPacket(char *buffer,
-			   QUsbTransfer::bmRequestType bmRequestType,
-			   QUsbTransfer::bRequest bRequest,
-			   quint16 wValue,
-			   quint16 wIndex,
-			   quint16 wLength) const;
+                           QUsbTransfer::bmRequestType bmRequestType,
+                           QUsbTransfer::bRequest bRequest,
+                           quint16 wValue,
+                           quint16 wIndex,
+                           quint16 wLength) const;
 
     void setPolling(bool enable);
     bool polling();


### PR DESCRIPTION
Hi,

I had a problem with my usb bulk transfer device.
On startup my device re/connects twice, so I modified your module to handle libusb errors on qusbtransfer.

I added properties status and connection to qusbdevice.
Also I changed handling of qusbtransfer errors on readUsb and writeUsb,
both functions calling qusbdevice and handle new status

For example - Hotplug device remove in `usbexample.cpp`

```
QObject::connect(m_usb_dev, &QUsbDevice::statusChanged, this, [this](QUsbDevice::DeviceStatus status){	    
	if (status != QUsbDevice::statusOK) {
		qWarning("Device disappeared...");
		this->closeDevice();	
	}     
});`
```
