### PR TITLE
Fix usage of QMutexLocker

### DIFF
--- a/src/usb/qusbendpoint.cpp
+++ b/src/usb/qusbendpoint.cpp
@@ -687,7 +687,7 @@ qint64 QUsbEndpoint::readData(char *data, qint64 maxSize)
     if (maxSize <= 0)
         return 0;
 
-    QMutexLocker(&d->m_buf_mutex);
+    QMutexLocker locker(&d->m_buf_mutex);
     qint64 read_size = d->m_buf.size();
     if (read_size == 0)
         return 0;


### PR DESCRIPTION
Discovered this bug in my Android application that was crashing when reading a video stream over USB. The back trace pointed to the `QUsbEndpoint::readData` function, and implementing this change fixed the issue. 

Also see here for reference
https://stackoverflow.com/questions/9607013/qmutexlocker-not-locking-qmutex