### PR TITLE
unregister QUsb hotplug callbacks on exit + cleanup

### DIFF
--- a/src/usb/qusb.cpp
+++ b/src/usb/qusb.cpp
@@ -266,7 +266,12 @@ QUsb::~QUsb()
 {
     Q_D(QUsb);
     DbgPrintFuncName();
-    libusb_hotplug_deregister_callback(d->m_ctx, callback_handle);
+    // Process any remaining events, then deregister hotplug callback
+    if (d->m_has_hotplug) {
+        timeval t = { 0, 0 };
+        libusb_handle_events_timeout_completed(d->m_ctx, &t, Q_NULLPTR);
+        libusb_hotplug_deregister_callback(d->m_ctx, callback_handle);
+    }
     libusb_exit(d->m_ctx);
 }
 

--- a/src/usb/qusbdevice_p.h
+++ b/src/usb/qusbdevice_p.h
@@ -37,12 +37,17 @@ class QUsbDevicePrivate : public QObjectPrivate
 
 public:
     QUsbDevicePrivate();
+    void registerDisconnectCallback(int vid, int pid);
+    void deregisterDisconnectCallback();
     ~QUsbDevicePrivate();
 
     libusb_device **m_devs;
     libusb_device_handle *m_devHandle;
     libusb_context *m_ctx;
+    libusb_hotplug_callback_handle m_callbackHandle;
     qusbdevice_classes_t m_classes;
+
+    bool m_hasHotplug;
 
     QUsbEventsThread *m_events;
 };


### PR DESCRIPTION
Trying some fixes for #77 

* Cleanup deregister on QUsb
* Move QUsbDevice register call to private class
* Add missing QUsbDevice deregister