### PR TITLE
Include QDebug in QUsb

### DIFF
--- a/src/usb/qusb.cpp
+++ b/src/usb/qusb.cpp
@@ -1,5 +1,6 @@
 #include "qusb.h"
 #include "qusb_p.h"
+#include <QDebug>
 #include <QThread>
 
 #define DbgPrintError() qWarning("In %s, at %s:%d", Q_FUNC_INFO, __FILE__, __LINE__)


### PR DESCRIPTION
In the various debug printing macros, we call qDebug, but never include its header.

I get compile errors on Windows MSVC.